### PR TITLE
Fix base44 client import and API modules

### DIFF
--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -1,0 +1,9 @@
+import { createClient } from '@base44/sdk';
+
+const serverUrl = import.meta.env.VITE_BASE44_SERVER_URL || 'https://base44.app';
+const appId = import.meta.env.VITE_BASE44_APP_ID || '';
+
+export const base44 = createClient({
+  serverUrl,
+  appId,
+});

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,13 +1,10 @@
 import { base44 } from './base44Client';
 
-
 export const GhostFollower = base44.entities.GhostFollower;
 
 export const UserProfile = base44.entities.UserProfile;
 
 export const ScanResult = base44.entities.ScanResult;
-
-
 
 // auth sdk:
 export const User = base44.auth;

--- a/src/api/functions.js
+++ b/src/api/functions.js
@@ -1,9 +1,6 @@
 import { base44 } from './base44Client';
 
-
 export const processUpload = base44.functions.processUpload;
 
-export const cleanupStalScans = base44.functions.cleanupStalScans;
-
-export const process-upload = base44.functions.process-upload;
+export const cleanupStaleScans = base44.functions.cleanupStaleScans;
 


### PR DESCRIPTION
## Summary
- add missing Base44 client wrapper
- correct typos in functions and entities modules

## Testing
- `npm run lint` *(fails: many prop-types and unused var errors)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6394c4f108330ad5cb562d1da0233