### PR TITLE
Fix static routing and add error boundary

### DIFF
--- a/src/ErrorBoundary.jsx
+++ b/src/ErrorBoundary.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: undefined }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  componentDidCatch(error) {
+    this.setState({ error })
+    console.error(error)
+  }
+
+  render() {
+    return this.state.error ? (
+      <div style={{ padding: 20, color: '#fff' }}>Something went wrong. Check console.</div>
+    ) : (
+      this.props.children
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -1,0 +1,5 @@
+export const base44 = {
+  entities: {},
+  auth: {},
+  functions: {}
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from '@/App.jsx'
 import '@/index.css'
+import ErrorBoundary from './ErrorBoundary.jsx'
+
+window.addEventListener('error', e => console.error('GlobalError:', e?.error || e))
+window.addEventListener('unhandledrejection', e => console.error('UnhandledRejection:', e?.reason))
 
 ReactDOM.createRoot(document.getElementById('root')).render(
+  <ErrorBoundary>
     <App />
-) 
+  </ErrorBoundary>
+)

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -22,7 +22,7 @@ import { format } from "date-fns";
 // Note: This function is no longer called by retryFailedScan due to explicit implementation within it.
 // It is kept for historical context or if other parts of a larger application might use it.
 async function startProcessUpload(scanId) {
-  const r = await fetch("/api/processUploadAPI", { // Changed endpoint path here
+  const r = await fetch("/api/process-upload", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ scanId })
@@ -100,7 +100,7 @@ export default function Admin() {
     if (!confirm('Retry this failed scan?')) return;
 
     try {
-      const r = await fetch("/api/processUploadAPI", {
+      const r = await fetch("/api/process-upload", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ scanId })

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -22,7 +22,7 @@ import AdminUserDetails from "./AdminUserDetails";
 
 import AdminUsers from "./AdminUsers";
 
-import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
+import { HashRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const PAGES = {
     

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,8 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/',
+  build: { outDir: 'dist' },
   plugins: [react()],
   server: {
     allowedHosts: true


### PR DESCRIPTION
## Summary
- switch BrowserRouter to HashRouter for static deployment
- add top-level ErrorBoundary and global error logging
- set Vite base path and build output dir
- correct API calls to `/api/process-upload`
- add stubbed Base44 client so build succeeds

## Testing
- `npm run lint` *(fails: many lint errors across repo)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b63a7ce2088330b69bc4f49f50fff2